### PR TITLE
Automate updating Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          # Either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # see https://goreleaser.com/errors/resource-not-accessible-by-integration
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,3 +38,20 @@ release:
   github:
     owner: g-core
     name: gcore-cli
+
+brews:
+  - name: gcore-cli
+    commit_author:
+      name: goreleaserbot
+      email: goreleaserbot@gcore.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    folder: Formula
+    homepage: "https://github.com/G-Core/gcore-cli"
+    description: "The official Gcore CLI"
+    license: "Apache-2.0"
+    skip_upload: auto
+    repository:
+      owner: G-Core
+      name: homebrew-tap
+      # see https://goreleaser.com/errors/resource-not-accessible-by-integration
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
I tried it locally and it seems to work fine. The generated formula references binaries from GitHub releases.

The only caveat is that we GitHub does not allow cross-repository operations without a Personal Access Token. More info in [goreleaser docs](https://goreleaser.com/errors/resource-not-accessible-by-integration/).