### PR TITLE
Don't fail help and completion commands on missing apikey

### DIFF
--- a/internal/core/root.go
+++ b/internal/core/root.go
@@ -47,6 +47,11 @@ func Execute() {
 	}
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		for _, safeCmd := range []string{"completion", "help"} {
+			if strings.Contains(cmd.CommandPath(), safeCmd) {
+				return nil
+			}
+		}
 		if *apiUrl == "" {
 			return &errors.CliError{
 				Message: "URL for API isn't specified",


### PR DESCRIPTION
Hotfixed the command tree to not check for `url` and `apikey` args when calling safe commands like `help` or `completion`. In the future, we should probably consider injecting this pre-run validation only to the commands that actually need it. 