### PR TITLE
Default flag values for fastedge app logs and sort parameter sanitization

### DIFF
--- a/internal/commands/fastedge/logs.go
+++ b/internal/commands/fastedge/logs.go
@@ -3,6 +3,7 @@ package fastedge
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"


### PR DESCRIPTION
New help shows this content:

```bash
Flags:
      --client-ip string   Client IP filter
      --edge string        Edge name filter
      --from string        Reporting period start, UTC (default "today")
  -h, --help               help for show
      --sort string        Log sort order, asc or desc (default "asc")
      --to string          Reporting period end, UTC (default "now")
```