### PR TITLE
Update README.md with correct go install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ brew install gcore-cli
 If you have [Go](https://go.dev) installed on your machine, you can install the CLI from sources with:
 
 ```sh
-go install github.com/g-core/gcore-cli/cmd/gcore-cli@latest
+go install github.com/G-core/gcore-cli/cmd/gcore-cli@latest
 ```
 
 ## Licensing


### PR DESCRIPTION
Previous go install command will throw an error:

```bash
go: github.com/g-core/gcore-cli/cmd/gcore-cli@latest: version constraints conflict:
	github.com/g-core/gcore-cli@v0.1.1: parsing go.mod:
	module declares its path as: github.com/G-core/gcore-cli
	        but was required as: github.com/g-core/gcore-cli
```