### PR TITLE
Update app logs pagination and get app id by name function

### DIFF
--- a/internal/commands/fastedge/app.go
+++ b/internal/commands/fastedge/app.go
@@ -447,7 +447,7 @@ func outputMap(m *map[string]string, title string) {
 }
 
 func getAppIdByName(appName string) (int64, error) {
-	idRsp, err := client.GetAppIdByNameWithResponse(context.Background(), appName)
+	idRsp, err := client.ListAppsWithResponse(context.Background(), &sdk.ListAppsParams{Name: &appName})
 	if err != nil {
 		return 0, fmt.Errorf("api response: %w", err)
 	}
@@ -457,5 +457,25 @@ func getAppIdByName(appName string) (int64, error) {
 	if idRsp.JSON200 == nil {
 		return 0, fmt.Errorf("app '%s' not found", appName)
 	}
-	return *idRsp.JSON200, nil
+	if len(idRsp.JSON200.Apps) != 1 {
+		return 0, fmt.Errorf("app '%s' not found", appName)
+	}
+	return idRsp.JSON200.Apps[0].Id, nil
+}
+
+func getAppByName(appName string) (sdk.AppShort, error) {
+	idRsp, err := client.ListAppsWithResponse(context.Background(), &sdk.ListAppsParams{Name: &appName})
+	if err != nil {
+		return sdk.AppShort{}, fmt.Errorf("api response: %w", err)
+	}
+	if idRsp.StatusCode() != http.StatusOK {
+		return sdk.AppShort{}, fmt.Errorf("%s", string(idRsp.Body))
+	}
+	if idRsp.JSON200 == nil {
+		return sdk.AppShort{}, fmt.Errorf("app '%s' not found", appName)
+	}
+	if len(idRsp.JSON200.Apps) != 1 {
+		return sdk.AppShort{}, fmt.Errorf("app '%s' not found", appName)
+	}
+	return idRsp.JSON200.Apps[0], nil
 }

--- a/internal/commands/fastedge/logs.go
+++ b/internal/commands/fastedge/logs.go
@@ -126,8 +126,8 @@ This command allows you filtering by edge name, client ip and time range.`,
 
 			if rsp.JSON200.Logs != nil {
 				printLogs(rsp.JSON200.Logs)
-				for *rsp.JSON200.CurrentPage < *rsp.JSON200.TotalPages {
-					fmt.Printf("Displaying %d/%d logs, load next page? (Y/n) ", *rsp.JSON200.CurrentPage**rsp.JSON200.PageSize, *rsp.JSON200.TotalPages**rsp.JSON200.PageSize)
+				for *rsp.JSON200.Offset < *rsp.JSON200.TotalCount {
+					fmt.Printf("Displaying %d/%d logs, load next page? (Y/n) ", *rsp.JSON200.Offset, *rsp.JSON200.TotalCount)
 					text, _ := reader.ReadString('\n')
 					text = strings.ToLower(strings.TrimSpace(text))
 
@@ -139,19 +139,23 @@ This command allows you filtering by edge name, client ip and time range.`,
 					fmt.Print("\033[2K\033[1A\033[2K\033[1A\n")
 
 					// Increment the page number
-					page := int64(*rsp.JSON200.CurrentPage + 1)
+					var (
+						offset = int32(*rsp.JSON200.Offset + 25)
+						limit  = int32(25)
+					)
 
 					// Call the API again with the new page number
 					rsp, err = client.GetV1AppsIdLogsWithResponse(
 						context.Background(),
 						id,
 						&sdk.GetV1AppsIdLogsParams{
-							From:        &from,
-							To:          &to,
-							Edge:        edge,
-							Sort:        sort,
-							ClientIp:    clientIp,
-							CurrentPage: &page,
+							From:     &from,
+							To:       &to,
+							Edge:     edge,
+							Sort:     sort,
+							ClientIp: clientIp,
+							Offset:   &offset,
+							Limit:    &limit,
 						},
 					)
 					if err != nil {


### PR DESCRIPTION
This will not be successfully built until we do not update SDK. This is minimal PR that we can have now; many changes are in the way with the new SDK update. 

We should probably think of totally removing `getAppIdByName` and use only `getAppByName` in the future, to remove redundant API call in some commands. 