### PR TITLE
Open PRs to homebrew tap repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,3 +61,5 @@ brews:
       name: homebrew-tap
       # see https://goreleaser.com/errors/resource-not-accessible-by-integration
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true


### PR DESCRIPTION
Looks like there is an organizational ruleset that forces approval on `master` and `main` branches. Because of that we can no longer push directly to [github.com/G-Core/homebrew-tap](https://github.com/G-Core/homebrew-tap) repo.

This PR switches goreleaser to create PRs instead.