### PR TITLE
Fix for PRs to homebrew tap repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,6 +59,7 @@ brews:
     repository:
       owner: G-Core
       name: homebrew-tap
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
       # see https://goreleaser.com/errors/resource-not-accessible-by-integration
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
       pull_request:


### PR DESCRIPTION
According to goreleaser [documentation](https://goreleaser.com/customization/homebrew/), the `branch` property must differ from the base for pull requests to work.