### PR TITLE
Don't run FOSSA for Dependabot jobs

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,6 +11,8 @@ jobs:
   fossa:
     runs-on: ubuntu-latest
 
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -19,12 +21,12 @@ jobs:
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 
-      - name: Set FOSSA API Key
-        run: echo "FOSSA_API_KEY=${{ secrets.FOSSA_PUB_API_KEY }}" >> $GITHUB_ENV
-
       - name: Run FOSSA Analysis
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_PUB_API_KEY }}
         run: fossa analyze
 
       - name: Run FOSSA Test
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_PUB_API_KEY }}
         run: fossa test
-


### PR DESCRIPTION
FOSSA workflow updated to skip Dependabot-originated jobs because Depandabot has no access to FOSSA API key